### PR TITLE
Move pieces cc

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -24,8 +24,13 @@ class GamesController < ApplicationController
 
   def update
     game = Game.find(params[:id])
-    game.update(black_player_id: current_user.id)
-    redirect_to game_path(game)
+    if game.white_player_id != current_user.id
+      game.update(black_player_id: current_user.id)
+      game.assign_black_side
+      redirect_to game_path(game)
+    else
+      render plain: "You are already in this game", status: :unauthorized
+    end
   end
 
 private

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -13,6 +13,8 @@ class PiecesController < ApplicationController
     piece = Piece.find(params[:id])
     if piece.valid_move?
       piece.update_attributes(piece_params)
+      render json: piece
+    #Else condition to handle response for invalid_moves
     end
   end
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -13,6 +13,11 @@ class Game < ApplicationRecord
     populate_black_side
   end
 
+  def assign_black_side
+    black_pieces = Piece.where(game_id: id, player_id: nil)
+    black_pieces.update_all(player_id: black_player_id)
+  end
+
   def populate_white_side
     populate_white_pawns
     populate_white_rooks

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -50,9 +50,20 @@ RSpec.describe GamesController, type: :controller do
       patch :update, params: { id: game.id, game: { black_player_id: user2.id } }
 
       game.reload
-      player2 = User.find_by(id: game.black_player_id)
+      #Verifies 2nd Player was added to the Game
       expect(game.black_player_id).to eq(user2.id)
+      player2 = User.find_by(id: game.black_player_id)
       expect(player2.username).to eq(user2.username)
+    end
+
+    it "will not allow two players with the same ID" do
+      user = FactoryBot.create(:user)
+      game = FactoryBot.create(:game, { white_player_id: user.id})
+      sign_in user
+
+      patch :update, params: { id: game.id, game: { black_player_id: user.id } }
+
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 end


### PR DESCRIPTION
This pull request includes 3 updates:
* Games will no longer accept users with the same user id for both players, to ensure there is no confusion in assigned player_ids
* Game model now includes a method to assign_black_player to populate the player_id of the black pieces
* Server sends the json of the single piece updated in the piece#update action

We may want to look at some cleanup together for:
* game model where black_player_id is assigned at game creation, rather than game update
* Adding tests for the piece_controller_spec and maybe some of the models