### PR TITLE
Valid moves cc

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,6 +1,5 @@
 class PiecesController < ApplicationController
   skip_before_action :verify_authenticity_token
-
   #Fetch request for pieces
   def index
     @game = Game.find(params[:game_id])
@@ -17,6 +16,7 @@ class PiecesController < ApplicationController
     new_y = piece_params[:y_position].to_i
     if piece.valid_move?(new_x, new_y)
       piece.update_attributes(piece_params)
+      piece.update_attribute(:updated_at, Time.now)
       render json: piece
     else
       #Else condition to handle response for invalid_moves

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -13,10 +13,13 @@ class PiecesController < ApplicationController
 
   def update
     piece = Piece.find(params[:id])
-    if piece.valid_move?
+    new_x = piece_params[:x_position].to_i
+    new_y = piece_params[:y_position].to_i
+    if piece.valid_move?(new_x, new_y)
       piece.update_attributes(piece_params)
       render json: piece
-    #Else condition to handle response for invalid_moves
+    else
+      #Else condition to handle response for invalid_moves
     end
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -17,7 +17,7 @@ class PiecesController < ApplicationController
     if piece.valid_move?(new_x, new_y)
       piece.update_attributes(piece_params)
       piece.update_attribute(:updated_at, Time.now)
-      render json: piece
+      head 200
     else
       #Else condition to handle response for invalid_moves
     end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -87,4 +87,8 @@ class Game < ApplicationRecord
       self.pieces.create(x_position: column+1, y_position: row)
     end
   end
+
+  def check_square(x, y)
+    self.pieces.find_by(x_position: x, y_position: y)
+  end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -6,4 +6,18 @@ class Pawn < Piece
     self.image = "&#9823"
   end
 
+  private
+
+  def valid_moves
+    if self.is_white_piece?
+      [
+        {x: self.x_position, y: self.y_position+1}
+      ]
+    else
+      [
+        {x: self.x_position, y: self.y_position-1}
+      ]
+    end
+  end
+
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -37,19 +37,9 @@ class Pawn < Piece
     if self.is_white_piece?
       check_and_add_square(x-1, y+1)
       check_and_add_square(x+1, y+1)
-      #left = self.game.check_square(self.x_position-1, self.y_position+1)
-      #if !left.nil? && left.color != self.color
-      #   @valid_moves.push({x: left.x_position, y: left.y_position})
-      # end
-      # right = self.game.check_square(self.x_position+1, self.y_position+1)
-      # if !right.nil? && right.color != self.color
-      #   @valid_moves.push({x: right.x_position, y: right.y_position})
-      # end
     else
-      right = self.game.check_square(self.x_position-1, self.y_position-1)
-      if !right.nil? && right.color != self.color
-        @valid_moves.push({x: right.x_position, y: right.y_position})
-      end
+      check_and_add_square(x-1, y-1)
+      check_and_add_square(x+1, y-1)
     end
   end
 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,5 +1,7 @@
 class Pawn < Piece
   belongs_to :game
+  #alias x x_position
+  #alias y y_position
 
   def image
     return self.image = "&#9817" if self.is_white_piece?
@@ -31,16 +33,34 @@ class Pawn < Piece
   end
 
   def add_enemy_diagonal
+    x,y = self.x_position, self.y_position
     if self.is_white_piece?
-      left = self.game.check_square(self.x_position+1, self.y_position+1)
-      if !left.nil? && left.color != self.color
-        @valid_moves.push({x: left.x_position, y: left.y_position})
-      end
+      check_and_add_square(x-1, y+1)
+      check_and_add_square(x+1, y+1)
+      #left = self.game.check_square(self.x_position-1, self.y_position+1)
+      #if !left.nil? && left.color != self.color
+      #   @valid_moves.push({x: left.x_position, y: left.y_position})
+      # end
+      # right = self.game.check_square(self.x_position+1, self.y_position+1)
+      # if !right.nil? && right.color != self.color
+      #   @valid_moves.push({x: right.x_position, y: right.y_position})
+      # end
     else
       right = self.game.check_square(self.x_position-1, self.y_position-1)
       if !right.nil? && right.color != self.color
         @valid_moves.push({x: right.x_position, y: right.y_position})
       end
     end
+  end
+
+  def check_and_add_square(x,y)
+    square = self.game.check_square(x, y)
+    if is_enemy(square)
+      @valid_moves.push({x: x, y: y})
+    end
+  end
+
+  def is_enemy(piece)
+    !piece.nil? && piece.color != self.color
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -8,13 +8,10 @@ class Pawn < Piece
 
   def valid_moves
     @valid_moves = []
+    add_enemy_diagonal
     if self.is_white_piece?
-      add_enemy_diagonal
       @valid_moves.push({x: self.x_position, y: self.y_position+1})
       @valid_moves.push({x: self.x_position, y: self.y_position+2}) if self.first_move?
-      # Determine the color of the found piece, and whether it's an opposing piece
-      # valid_moves.push({x: self.x_position+1, y: self.y_position+1})
-      # valid_moves.push({x: self.x_position-1, y: self.y_position+1})
     else
       @valid_moves.push({x: self.x_position, y: self.y_position-1})
       @valid_moves.push({x: self.x_position, y: self.y_position-2}) if self.first_move?
@@ -34,13 +31,16 @@ class Pawn < Piece
   end
 
   def add_enemy_diagonal
-    # if self.is_white_piece?
+    if self.is_white_piece?
       left = self.game.check_square(self.x_position+1, self.y_position+1)
       if !left.nil? && left.color != self.color
         @valid_moves.push({x: left.x_position, y: left.y_position})
       end
-      #right = self.game.check_square(self.x_position-1, self.y_position+1)
-      #if !right.nil? && right.color != self.color then self.valid_moves.push(right.x_position, right.y_position) end
-    #end
+    else
+      right = self.game.check_square(self.x_position-1, self.y_position-1)
+      if !right.nil? && right.color != self.color
+        @valid_moves.push({x: right.x_position, y: right.y_position})
+      end
+    end
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -13,10 +13,42 @@ class Pawn < Piece
     if self.is_white_piece?
       valid_moves.push({x: self.x_position, y: self.y_position+1})
       valid_moves.push({x: self.x_position, y: self.y_position+2}) if self.first_move?
+      valid_moves.push({x: self.x_position+1, y: self.y_position+1}) if can_capture?(self.x_position+1, self.y_position+1, "black")
+      valid_moves.push({x: self.x_position-1, y: self.y_position+1}) if can_capture?(self.x_position-1, self.y_position+1, "black")
     else
       valid_moves.push({x: self.x_position, y: self.y_position-1})
       valid_moves.push({x: self.x_position, y: self.y_position-2}) if self.first_move?
     end
     return valid_moves
+  end
+
+  # def valid_capture(x, y)
+  #   #Determine array of valid captures
+  #   if self.is_white_piece?
+  #     valid_captures = [
+  #       {x: self.x_position+1, y: self.y_position+1},
+  #       {x: self.x_position-1, y: self.y_position+1}]
+  #     opponant = "black"
+  #   else
+  #     valid_captures = [
+  #       {x: self.x_position+1, y: self.y_position-1},
+  #       {x: self.x_position-1, y: self.y_position-1}]
+  #     opponant = "white"
+  #   end
+  #   unoccupied = false if Piece.where(x_position: x, y_position: y, color: opponant, game_id: self.game_id) == nil #Compare array to proposed move, and confirm the color
+  #   if !unoccupied && valid_captures.include?({x: x, y: y})
+  #     return true
+  #   else
+  #     return false
+  #   end
+  # end
+
+  private
+  def can_capture?(x, y, color)
+    if Piece.where(x_position: x, y_position: y, color: color, game_id: self.game_id) != nil
+      return true
+    else
+      return false
+    end
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,7 +1,7 @@
 class Pawn < Piece
   belongs_to :game
-  #alias x x_position
-  #alias y y_position
+  alias_attribute :x, :x_position
+  alias_attribute :y, :y_position
 
   def image
     return self.image = "&#9817" if self.is_white_piece?
@@ -12,28 +12,16 @@ class Pawn < Piece
     @valid_moves = []
     add_enemy_diagonal
     if self.is_white_piece?
-      @valid_moves.push({x: self.x_position, y: self.y_position+1})
-      @valid_moves.push({x: self.x_position, y: self.y_position+2}) if self.first_move?
+      @valid_moves.push({x: x, y: y+1})
+      @valid_moves.push({x: x, y: y+2}) if self.first_move?
     else
-      @valid_moves.push({x: self.x_position, y: self.y_position-1})
-      @valid_moves.push({x: self.x_position, y: self.y_position-2}) if self.first_move?
+      @valid_moves.push({x: x, y: y-1})
+      @valid_moves.push({x: x, y: y-2}) if self.first_move?
     end
-    return @valid_moves
-  end
-
-  def has_enemy_diagonal
-    if self.is_white_piece?
-      if self.game.check_square(self.x_position+1, self.y_position+1).nil?
-        return false
-      end
-      square = !self.game.check_square(self.x_position+1, self.y_position+1).is_white_piece?
-    else
-      return self.game.check_square(self.x_position-1, self.y_position-1).is_white_piece?
-    end
+    @valid_moves
   end
 
   def add_enemy_diagonal
-    x,y = self.x_position, self.y_position
     if self.is_white_piece?
       check_and_add_square(x-1, y+1)
       check_and_add_square(x+1, y+1)

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -6,49 +6,17 @@ class Pawn < Piece
     self.image = "&#9823"
   end
 
-  private
-
   def valid_moves
     valid_moves = []
     if self.is_white_piece?
       valid_moves.push({x: self.x_position, y: self.y_position+1})
       valid_moves.push({x: self.x_position, y: self.y_position+2}) if self.first_move?
-      valid_moves.push({x: self.x_position+1, y: self.y_position+1}) if can_capture?(self.x_position+1, self.y_position+1, "black")
-      valid_moves.push({x: self.x_position-1, y: self.y_position+1}) if can_capture?(self.x_position-1, self.y_position+1, "black")
+      # valid_moves.push({x: self.x_position+1, y: self.y_position+1}) 
+      # valid_moves.push({x: self.x_position-1, y: self.y_position+1})
     else
       valid_moves.push({x: self.x_position, y: self.y_position-1})
       valid_moves.push({x: self.x_position, y: self.y_position-2}) if self.first_move?
     end
     return valid_moves
-  end
-
-  # def valid_capture(x, y)
-  #   #Determine array of valid captures
-  #   if self.is_white_piece?
-  #     valid_captures = [
-  #       {x: self.x_position+1, y: self.y_position+1},
-  #       {x: self.x_position-1, y: self.y_position+1}]
-  #     opponant = "black"
-  #   else
-  #     valid_captures = [
-  #       {x: self.x_position+1, y: self.y_position-1},
-  #       {x: self.x_position-1, y: self.y_position-1}]
-  #     opponant = "white"
-  #   end
-  #   unoccupied = false if Piece.where(x_position: x, y_position: y, color: opponant, game_id: self.game_id) == nil #Compare array to proposed move, and confirm the color
-  #   if !unoccupied && valid_captures.include?({x: x, y: y})
-  #     return true
-  #   else
-  #     return false
-  #   end
-  # end
-
-  private
-  def can_capture?(x, y, color)
-    if Piece.where(x_position: x, y_position: y, color: color, game_id: self.game_id) != nil
-      return true
-    else
-      return false
-    end
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -7,18 +7,19 @@ class Pawn < Piece
   end
 
   def valid_moves
-    valid_moves = []
+    @valid_moves = []
     if self.is_white_piece?
-      valid_moves.push({x: self.x_position, y: self.y_position+1})
-      valid_moves.push({x: self.x_position, y: self.y_position+2}) if self.first_move?
+      add_enemy_diagonal
+      @valid_moves.push({x: self.x_position, y: self.y_position+1})
+      @valid_moves.push({x: self.x_position, y: self.y_position+2}) if self.first_move?
       # Determine the color of the found piece, and whether it's an opposing piece
       # valid_moves.push({x: self.x_position+1, y: self.y_position+1})
       # valid_moves.push({x: self.x_position-1, y: self.y_position+1})
     else
-      valid_moves.push({x: self.x_position, y: self.y_position-1})
-      valid_moves.push({x: self.x_position, y: self.y_position-2}) if self.first_move?
+      @valid_moves.push({x: self.x_position, y: self.y_position-1})
+      @valid_moves.push({x: self.x_position, y: self.y_position-2}) if self.first_move?
     end
-    return valid_moves
+    return @valid_moves
   end
 
   def has_enemy_diagonal
@@ -33,12 +34,13 @@ class Pawn < Piece
   end
 
   def add_enemy_diagonal
-    if self.is_white_piece?
-      #Right diagonal
+    # if self.is_white_piece?
       left = self.game.check_square(self.x_position+1, self.y_position+1)
-      if !left.nil? && left.color != self.color then self.valid_moves.push(left.x_position, left.y_position) end
-      right = self.game.check_square(self.x_position-1, self.y_position+1)
-      if !right.nil? && right.color != self.color then self.valid_moves.push(right.x_position, right.y_position) end
-    end
+      if !left.nil? && left.color != self.color
+        @valid_moves.push({x: left.x_position, y: left.y_position})
+      end
+      #right = self.game.check_square(self.x_position-1, self.y_position+1)
+      #if !right.nil? && right.color != self.color then self.valid_moves.push(right.x_position, right.y_position) end
+    #end
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -9,15 +9,14 @@ class Pawn < Piece
   private
 
   def valid_moves
+    valid_moves = []
     if self.is_white_piece?
-      [
-        {x: self.x_position, y: self.y_position+1}
-      ]
+      valid_moves.push({x: self.x_position, y: self.y_position+1})
+      valid_moves.push({x: self.x_position, y: self.y_position+2}) if self.first_move?
     else
-      [
-        {x: self.x_position, y: self.y_position-1}
-      ]
+      valid_moves.push({x: self.x_position, y: self.y_position-1})
+      valid_moves.push({x: self.x_position, y: self.y_position-2}) if self.first_move?
     end
+    return valid_moves
   end
-
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -11,12 +11,34 @@ class Pawn < Piece
     if self.is_white_piece?
       valid_moves.push({x: self.x_position, y: self.y_position+1})
       valid_moves.push({x: self.x_position, y: self.y_position+2}) if self.first_move?
-      # valid_moves.push({x: self.x_position+1, y: self.y_position+1}) 
+      # Determine the color of the found piece, and whether it's an opposing piece
+      # valid_moves.push({x: self.x_position+1, y: self.y_position+1})
       # valid_moves.push({x: self.x_position-1, y: self.y_position+1})
     else
       valid_moves.push({x: self.x_position, y: self.y_position-1})
       valid_moves.push({x: self.x_position, y: self.y_position-2}) if self.first_move?
     end
     return valid_moves
+  end
+
+  def has_enemy_diagonal
+    if self.is_white_piece?
+      if self.game.check_square(self.x_position+1, self.y_position+1).nil?
+        return false
+      end
+      square = !self.game.check_square(self.x_position+1, self.y_position+1).is_white_piece?
+    else
+      return self.game.check_square(self.x_position-1, self.y_position-1).is_white_piece?
+    end
+  end
+
+  def add_enemy_diagonal
+    if self.is_white_piece?
+      #Right diagonal
+      left = self.game.check_square(self.x_position+1, self.y_position+1)
+      if !left.nil? && left.color != self.color then self.valid_moves.push(left.x_position, left.y_position) end
+      right = self.game.check_square(self.x_position-1, self.y_position+1)
+      if !right.nil? && right.color != self.color then self.valid_moves.push(right.x_position, right.y_position) end
+    end
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -3,6 +3,7 @@ class Piece < ApplicationRecord
   self.inheritance_column = 'piece_type'
   belongs_to :game
   attr_accessor :image
+  after_create :get_starting_location
 
   def as_json(options={})
     super(only: [:id, :x_position, :y_position, :player_id, :piece_type, :image, :color],
@@ -16,4 +17,16 @@ class Piece < ApplicationRecord
   def is_white_piece?
     color == "white"
   end
+
+  def has_been_moved?
+    [self.x_position, self.y_position] != @starting_location
+  end
+
+  private
+
+  def get_starting_location
+    @starting_location = [self.x_position, self.y_position]
+  end
+
+
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -9,12 +9,11 @@ class Piece < ApplicationRecord
           methods: [:image])
   end
 
-  def valid_move?
-    return true
-    #Piece specific - effectively calling that piece model
+  def valid_move?(x, y)
+    valid_moves.include?({x: x, y: y})
   end
 
   def is_white_piece?
-    player_id == Game.find(self.game_id).white_player_id
+    color == "white"
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -3,10 +3,6 @@ class Piece < ApplicationRecord
   self.inheritance_column = 'piece_type'
   belongs_to :game
   attr_accessor :image
-  attr_accessor :move_count
-  after_update :mark_as_moved
-
-  @move_count = 0
 
   def as_json(options={})
     super(only: [:id, :x_position, :y_position, :player_id, :piece_type, :image, :color],
@@ -21,15 +17,14 @@ class Piece < ApplicationRecord
     color == "white"
   end
 
-  def has_been_moved? 
-    @move_count == 1
+  def first_move?
+    if created_at == updated_at
+      return true
+    else
+      return false
+    end
   end
 
   private
-
-  def mark_as_moved
-    @move_count = 1
-  end
-
 
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -3,7 +3,10 @@ class Piece < ApplicationRecord
   self.inheritance_column = 'piece_type'
   belongs_to :game
   attr_accessor :image
-  after_create :get_starting_location
+  attr_accessor :move_count
+  after_update :mark_as_moved
+
+  @move_count = 0
 
   def as_json(options={})
     super(only: [:id, :x_position, :y_position, :player_id, :piece_type, :image, :color],
@@ -18,14 +21,14 @@ class Piece < ApplicationRecord
     color == "white"
   end
 
-  def has_been_moved?
-    [self.x_position, self.y_position] != @starting_location
+  def has_been_moved? 
+    @move_count == 1
   end
 
   private
 
-  def get_starting_location
-    @starting_location = [self.x_position, self.y_position]
+  def mark_as_moved
+    @move_count = 1
   end
 
 

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -19,23 +19,25 @@ RSpec.describe PiecesController, type: :controller do
       white_pawn = FactoryBot.create(:sample_white_pawn)
       game = Game.find(white_pawn.game_id)
 
-      patch :update, params: { game_id: game.id, id: white_pawn.id, use_route: game_piece_path(game, white_pawn), piece: { y_position: white_pawn.y_position + 1 } }
+      patch :update, params: { game_id: game.id, id: white_pawn.id, use_route: game_piece_path(game, white_pawn), piece: { x_position: 1, y_position: 2 } }
 
       expect(response).to have_http_status(:success)
+      white_pawn.reload
+      expect(white_pawn.y_position).to eq(2)
     end
+  end
 
-    describe "pieces#destroy" do
-      it "removes a captured piece" do
-        white_pawn = FactoryBot.create(:sample_white_pawn)
-        game = Game.find(white_pawn.game_id)
+  describe "pieces#destroy" do
+    it "removes a captured piece" do
+      white_pawn = FactoryBot.create(:sample_white_pawn)
+      game = Game.find(white_pawn.game_id)
 
-        delete :destroy, params: { game_id: game.id, id: white_pawn.id, use_route: game_piece_path(game, white_pawn) }
+      delete :destroy, params: { game_id: game.id, id: white_pawn.id, use_route: game_piece_path(game, white_pawn) }
 
-        expect(response).to have_http_status(:success)
-        white_pawn.reload
-        expect(white_pawn.x_position).to eq nil
-        expect(white_pawn.y_position).to eq nil
-      end
+      expect(response).to have_http_status(:success)
+      white_pawn.reload
+      expect(white_pawn.x_position).to eq nil
+      expect(white_pawn.y_position).to eq nil
     end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe Game, type: :model do
       expect(Game.available.count).to eq 1
     end
   end
+
+  describe "#check_square" do
+    it "gives the piece at a specific coordinate" do
+      game = FactoryBot.create :sample_game
+      game.populate_white_pawns
+      pawn = game.pieces.first
+
+      expect(game.check_square(pawn.x_position, pawn.y_position)).to be_instance_of(Pawn)
+    end
+  end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -152,27 +152,39 @@ RSpec.describe Pawn, type: :model do
 
 
   describe "#add_enemy_diagonal" do
-    fit "should update valid_moves with a diagonal square occupied by an enemy" do
-      game = FactoryBot.create(:sample_game)
-      white_pawn = FactoryBot.create :sample_white_pawn,
-                  x_position: 3, y_position: 3, game_id: game.id
-      black_pawn = FactoryBot.create :sample_black_pawn,
-                  x_position: 4, y_position: 4, game_id: game.id 
-      expect(white_pawn.valid_moves).to include({ x: 4, y: 4 })
+    context "white piece" do
+      fit "should update valid_moves with a diagonal square occupied by an enemy" do
+        game = FactoryBot.create(:sample_game)
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                    x_position: 3, y_position: 3, game_id: game.id
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                    x_position: 4, y_position: 4, game_id: game.id 
+        expect(white_pawn.valid_moves).to include({ x: 4, y: 4 })
+      end
+      fit "should not update valid_moves with a diagonal square occupied by yourself" do
+        game = FactoryBot.create(:sample_game)
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                    x_position: 3, y_position: 3, game_id: game.id
+        white_pawn2 = FactoryBot.create :sample_white_pawn,
+                    x_position: 4, y_position: 4, game_id: game.id        
+        expect(white_pawn.valid_moves).not_to include({ x: 4, y: 4 })
+      end
+      fit "should not update valid_moves with an unoccupied diagonal square" do
+        game = FactoryBot.create(:sample_game)
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                    x_position: 3, y_position: 3, game_id: game.id        
+        expect(white_pawn.valid_moves).not_to include({ x: 4, y: 4 })
+      end
     end
-    fit "should not update valid_moves with a diagonal square occupied by yourself" do
-      game = FactoryBot.create(:sample_game)
-      white_pawn = FactoryBot.create :sample_white_pawn,
-                  x_position: 3, y_position: 3, game_id: game.id
-      white_pawn2 = FactoryBot.create :sample_white_pawn,
-                  x_position: 4, y_position: 4, game_id: game.id        
-      expect(white_pawn.valid_moves).not_to include({ x: 4, y: 4 })
-    end
-    fit "should not update valid_moves with an unoccupied diagonal square" do
-      game = FactoryBot.create(:sample_game)
-      white_pawn = FactoryBot.create :sample_white_pawn,
-                  x_position: 3, y_position: 3, game_id: game.id        
-      expect(white_pawn.valid_moves).not_to include({ x: 4, y: 4 })
+    context "black piece" do
+      fit "should update valid_moves with a diagonal square occupied by a white pawn" do
+        game = FactoryBot.create(:sample_game)
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                       x_position: 2, y_position: 2, game_id: game.id
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                       x_position: 3, y_position: 3, game_id: game.id        
+        expect(black_pawn.valid_moves).to include({ x: 2, y: 2 })
+      end
     end
   end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -36,22 +36,14 @@ RSpec.describe Pawn, type: :model do
         expect(white_pawn.valid_move?(3,6)).to be false
       end
 
-      fit "can capture a black pawn diagonally" do
+      it "can capture a black pawn diagonally" do
+        game = FactoryBot.create(:sample_game)
         white_pawn = FactoryBot.create :sample_white_pawn,
-                     x_position: 3, y_position: 3
+                        x_position: 3, y_position: 3, game_id: game.id
         black_pawn = FactoryBot.create :sample_black_pawn,
-                     x_position: 4, y_position: 4
-
-        # expect(self.game.check_square(black_pawn.x_position, black_pawn.y_position)).to be_instance_of(Pawn)
+                        x_position: 4, y_position: 4, game_id: game.id
         expect(white_pawn.valid_move?(black_pawn.x_position, black_pawn.y_position)).to be true
       end
-
-      # it "cannot move diagonally if it cannot capture a black pawn" do
-      #   white_pawn = FactoryBot.create :sample_white_pawn,
-      #                x_position: 3, y_position: 3
-        
-      #   expect(white_pawn.valid_move?(2,4)).to be false
-      # end
     end
     context "black piece" do
       it "can move forward" do
@@ -79,73 +71,14 @@ RSpec.describe Pawn, type: :model do
         expect(black_pawn.valid_move?(3,1)).to be false
       end
 
-      # it "can capture a white pawn diagonally" do
-      #   black_pawn = FactoryBot.create :sample_black_pawn,
-      #                x_position: 3, y_position: 3
-      #   white_pawn = FactoryBot.create :sample_white_pawn,
-      #                x_position: 2, y_position: 2
-
-      #   expect(black_pawn.valid_move?(2,2)).to be true
-      # end
-
-      # it "cannot move diagonally if it cannot capture a white pawn" do
-      #   black_pawn = FactoryBot.create :sample_black_pawn,
-      #                x_position: 3, y_position: 3
-
-      #   expect(black_pawn.valid_move?(4,2)).to be false
-      # end
-    end
-  end
-
-  describe "#has_enemy_diagonal" do
-    context "white piece" do
-      it "says whether a white piece has an enemy black pawn in a diagonal square" do
+      it "can capture a white pawn diagonally" do
         game = FactoryBot.create(:sample_game)
-        white_pawn = FactoryBot.create :sample_white_pawn,
-                       x_position: 3, y_position: 3, game_id: game.id
         black_pawn = FactoryBot.create :sample_black_pawn,
-                       x_position: 4, y_position: 4, game_id: game.id
-        
-        expect(white_pawn.has_enemy_diagonal).to be true
-      end
-
-      it "returns false if it is the player's own piece in the specified square" do
-        game = FactoryBot.create(:sample_game)
-        white_pawn = FactoryBot.create :sample_white_pawn,
-                        x_position: 3, y_position: 3, game_id: game.id
-        white_pawn2 = FactoryBot.create :sample_white_pawn,
-                        x_position: 4, y_position: 4, game_id: game.id
-        
-        expect(white_pawn.has_enemy_diagonal).to be false
-      end
-
-      it "returns false if there is no piece in the specified square" do
-        game = FactoryBot.create(:sample_game)
-        white_pawn = FactoryBot.create :sample_white_pawn,
-                        x_position: 3, y_position: 3, game_id: game.id
-
-        expect(white_pawn.has_enemy_diagonal).to be false
-      end
-    end
-    context "black piece" do
-       it "says whether a black piece has an enemy white pawn in a diagonal square" do
-        game = FactoryBot.create(:sample_game)
+                       x_position: 3, y_position: 3, game_id: game.id
         white_pawn = FactoryBot.create :sample_white_pawn,
                        x_position: 2, y_position: 2, game_id: game.id
-        black_pawn = FactoryBot.create :sample_black_pawn,
-                       x_position: 3, y_position: 3, game_id: game.id
-        
-        expect(black_pawn.has_enemy_diagonal).to be true
-      end
 
-      it "returns false if it is the player's own piece in the specified square" do
-        game = FactoryBot.create(:sample_game)
-        black_pawn = FactoryBot.create :sample_black_pawn,
-                       x_position: 3, y_position: 3, game_id: game.id
-        black_pawn2 = FactoryBot.create :sample_black_pawn,
-                       x_position: 2, y_position: 2, game_id: game.id
-        
-        expect(black_pawn.has_enemy_diagonal).to be false
+        expect(black_pawn.valid_move?(2,2)).to be true
       end
     end
   end
@@ -153,7 +86,7 @@ RSpec.describe Pawn, type: :model do
 
   describe "#add_enemy_diagonal" do
     context "white piece" do
-      fit "should update valid_moves with a diagonal square occupied by an enemy" do
+      it "should update valid_moves with a diagonal square occupied by an enemy" do
         game = FactoryBot.create(:sample_game)
         white_pawn = FactoryBot.create :sample_white_pawn,
                     x_position: 3, y_position: 3, game_id: game.id
@@ -164,7 +97,7 @@ RSpec.describe Pawn, type: :model do
         expect(white_pawn.valid_moves).to include({ x: 4, y: 4 })
         expect(white_pawn.valid_moves).to include({ x: 2, y: 4 }) 
       end
-      fit "should not update valid_moves with a diagonal square occupied by yourself" do
+      it "should not update valid_moves with a diagonal square occupied by yourself" do
         game = FactoryBot.create(:sample_game)
         white_pawn = FactoryBot.create :sample_white_pawn,
                     x_position: 3, y_position: 3, game_id: game.id
@@ -172,7 +105,7 @@ RSpec.describe Pawn, type: :model do
                     x_position: 4, y_position: 4, game_id: game.id        
         expect(white_pawn.valid_moves).not_to include({ x: 4, y: 4 })
       end
-      fit "should not update valid_moves with an unoccupied diagonal square" do
+      it "should not update valid_moves with an unoccupied diagonal square" do
         game = FactoryBot.create(:sample_game)
         white_pawn = FactoryBot.create :sample_white_pawn,
                     x_position: 3, y_position: 3, game_id: game.id        
@@ -180,7 +113,7 @@ RSpec.describe Pawn, type: :model do
       end
     end
     context "black piece" do
-      fit "should update valid_moves with a diagonal square occupied by a white pawn" do
+      it "should update valid_moves with a diagonal square occupied by a white pawn" do
         game = FactoryBot.create(:sample_game)
         white_pawn = FactoryBot.create :sample_white_pawn,
                        x_position: 2, y_position: 2, game_id: game.id
@@ -191,7 +124,7 @@ RSpec.describe Pawn, type: :model do
         expect(black_pawn.valid_moves).to include({ x: 2, y: 2 })
         expect(black_pawn.valid_moves).to include({ x: 4, y: 2 })
       end
-      fit "should not update valid_moves with a diagonal square occupied by a black pawn" do
+      it "should not update valid_moves with a diagonal square occupied by a black pawn" do
         game = FactoryBot.create(:sample_game)
         black_pawn = FactoryBot.create :sample_black_pawn,
                        x_position: 3, y_position: 3, game_id: game.id
@@ -199,7 +132,7 @@ RSpec.describe Pawn, type: :model do
                        x_position: 2, y_position: 2, game_id: game.id        
         expect(black_pawn.valid_moves).not_to include({ x: 2, y: 2 })
       end      
-      fit "should not update valid_moves with an unoccupied diagonal square" do
+      it "should not update valid_moves with an unoccupied diagonal square" do
         game = FactoryBot.create(:sample_game)
         black_pawn = FactoryBot.create :sample_black_pawn,
                        x_position: 3, y_position: 3, game_id: game.id        

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe Pawn, type: :model do
 
         expect(white_pawn.valid_move?(3,6)).to be false
       end
+
+      it "can capture a black pawn diagonally" do
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                     x_position: 3, y_position: 3
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                     x_position: 4, y_position: 4
+
+        expect(white_pawn.valid_move?(4,4)).to be true
+      end
+
+      it "cannot move diagonally if it cannot capture a black pawn" do
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                     x_position: 3, y_position: 3
+        
+        expect(white_pawn.valid_move?(4,4)).to be false
+      end
     end
     context "black piece" do
       it "can move forward" do
@@ -60,6 +76,22 @@ RSpec.describe Pawn, type: :model do
         black_pawn.update_attributes({ x_position: 3, y_position: 3})
 
         expect(black_pawn.valid_move?(3,1)).to be false
+      end
+
+      it "can capture a white pawn diagonally" do
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                     x_position: 3, y_position: 3
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                     x_position: 2, y_position: 2
+
+        expect(black_pawn.valid_move?(2,2)).to be true
+      end
+
+      it "cannot move diagonally if it cannot capture a white pawn" do
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                     x_position: 3, y_position: 3
+
+        expect(black_pawn.valid_move?(2,2)).to be false
       end
     end
   end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -36,14 +36,15 @@ RSpec.describe Pawn, type: :model do
         expect(white_pawn.valid_move?(3,6)).to be false
       end
 
-      # it "can capture a black pawn diagonally" do
-      #   white_pawn = FactoryBot.create :sample_white_pawn,
-      #                x_position: 3, y_position: 3
-      #   black_pawn = FactoryBot.create :sample_black_pawn,
-      #                x_position: 4, y_position: 4
+      fit "can capture a black pawn diagonally" do
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                     x_position: 3, y_position: 3
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                     x_position: 4, y_position: 4
 
-      #   expect(white_pawn.valid_move?(4,4)).to be true
-      # end
+        # expect(self.game.check_square(black_pawn.x_position, black_pawn.y_position)).to be_instance_of(Pawn)
+        expect(white_pawn.valid_move?(black_pawn.x_position, black_pawn.y_position)).to be true
+      end
 
       # it "cannot move diagonally if it cannot capture a black pawn" do
       #   white_pawn = FactoryBot.create :sample_white_pawn,
@@ -96,14 +97,56 @@ RSpec.describe Pawn, type: :model do
     end
   end
 
-  # describe "#can_capture?" do
-  #   it "checks if there is a piece in that spot and it is not yours" do
-  #     white_pawn = FactoryBot.create :sample_white_pawn,
-  #                  x_position: 3, y_position: 3
-  #     black_pawn = FactoryBot.create :sample_black_pawn,
-  #                  x_position: 4, y_position: 4
+  describe "#has_enemy_diagonal" do
+    context "white piece" do
+      fit "says whether a white piece has an enemy black pawn in a diagonal square" do
+        game = FactoryBot.create(:sample_game)
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                       x_position: 3, y_position: 3, game_id: game.id
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                       x_position: 4, y_position: 4, game_id: game.id
+        
+        expect(white_pawn.has_enemy_diagonal).to be true
+      end
 
-  #     expect(white_pawn.can_capture?(black_pawn.x_position, black_pawn.y_position, black_pawn.color)).to be true
-  #   end
-  # end
+      fit "returns false if it is the player's own piece in the specified square" do
+        game = FactoryBot.create(:sample_game)
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                        x_position: 3, y_position: 3, game_id: game.id
+        white_pawn2 = FactoryBot.create :sample_white_pawn,
+                        x_position: 4, y_position: 4, game_id: game.id
+        
+        expect(white_pawn.has_enemy_diagonal).to be false
+      end
+
+      fit "returns false if there is no piece in the specified square" do
+        game = FactoryBot.create(:sample_game)
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                        x_position: 3, y_position: 3, game_id: game.id
+
+        expect(white_pawn.has_enemy_diagonal).to be false
+      end
+    end
+    context "black piece" do
+       it "says whether a black piece has an enemy white pawn in a diagonal square" do
+        game = FactoryBot.create(:sample_game)
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                       x_position: 2, y_position: 2, game_id: game.id
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                       x_position: 3, y_position: 3, game_id: game.id
+        
+        expect(black_pawn.has_enemy_diagonal).to be true
+      end
+
+      it "returns false if it is the player's own piece in the specified square" do
+        game = FactoryBot.create(:sample_game)
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                       x_position: 3, y_position: 3, game_id: game.id
+        black_pawn2 = FactoryBot.create :sample_black_pawn,
+                       x_position: 2, y_position: 2, game_id: game.id
+        
+        expect(black_pawn.has_enemy_diagonal).to be false
+      end
+    end
+  end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -8,4 +8,31 @@ RSpec.describe Pawn, type: :model do
       expect(game.pawns.find_by(y_position: 2).image).to eq "&#9817"
     end
   end
+
+  describe "#valid_move?" do
+    context "white piece" do
+      it "can move forward" do
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                     x_position: 3, y_position: 3
+        expect(white_pawn.valid_move?(3,4)).to be true
+      end
+      it "cannot move backward" do
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                     x_position: 3, y_position: 3
+        expect(white_pawn.valid_move?(3,2)).to be false
+      end
+    end
+    context "black piece" do
+      it "can move forward" do
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                     x_position: 3, y_position: 3
+        expect(black_pawn.valid_move?(3,2)).to be true
+      end
+      it "cannot move backward" do
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                     x_position: 3, y_position: 3
+        expect(black_pawn.valid_move?(3,4)).to be false
+      end
+    end
+  end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -36,21 +36,21 @@ RSpec.describe Pawn, type: :model do
         expect(white_pawn.valid_move?(3,6)).to be false
       end
 
-      it "can capture a black pawn diagonally" do
-        white_pawn = FactoryBot.create :sample_white_pawn,
-                     x_position: 3, y_position: 3
-        black_pawn = FactoryBot.create :sample_black_pawn,
-                     x_position: 4, y_position: 4
+      # it "can capture a black pawn diagonally" do
+      #   white_pawn = FactoryBot.create :sample_white_pawn,
+      #                x_position: 3, y_position: 3
+      #   black_pawn = FactoryBot.create :sample_black_pawn,
+      #                x_position: 4, y_position: 4
 
-        expect(white_pawn.valid_move?(4,4)).to be true
-      end
+      #   expect(white_pawn.valid_move?(4,4)).to be true
+      # end
 
-      it "cannot move diagonally if it cannot capture a black pawn" do
-        white_pawn = FactoryBot.create :sample_white_pawn,
-                     x_position: 3, y_position: 3
+      # it "cannot move diagonally if it cannot capture a black pawn" do
+      #   white_pawn = FactoryBot.create :sample_white_pawn,
+      #                x_position: 3, y_position: 3
         
-        expect(white_pawn.valid_move?(2,4)).to be false
-      end
+      #   expect(white_pawn.valid_move?(2,4)).to be false
+      # end
     end
     context "black piece" do
       it "can move forward" do
@@ -78,21 +78,32 @@ RSpec.describe Pawn, type: :model do
         expect(black_pawn.valid_move?(3,1)).to be false
       end
 
-      it "can capture a white pawn diagonally" do
-        black_pawn = FactoryBot.create :sample_black_pawn,
-                     x_position: 3, y_position: 3
-        white_pawn = FactoryBot.create :sample_white_pawn,
-                     x_position: 2, y_position: 2
+      # it "can capture a white pawn diagonally" do
+      #   black_pawn = FactoryBot.create :sample_black_pawn,
+      #                x_position: 3, y_position: 3
+      #   white_pawn = FactoryBot.create :sample_white_pawn,
+      #                x_position: 2, y_position: 2
 
-        expect(black_pawn.valid_move?(2,2)).to be true
-      end
+      #   expect(black_pawn.valid_move?(2,2)).to be true
+      # end
 
-      it "cannot move diagonally if it cannot capture a white pawn" do
-        black_pawn = FactoryBot.create :sample_black_pawn,
-                     x_position: 3, y_position: 3
+      # it "cannot move diagonally if it cannot capture a white pawn" do
+      #   black_pawn = FactoryBot.create :sample_black_pawn,
+      #                x_position: 3, y_position: 3
 
-        expect(black_pawn.valid_move?(4,2)).to be false
-      end
+      #   expect(black_pawn.valid_move?(4,2)).to be false
+      # end
     end
   end
+
+  # describe "#can_capture?" do
+  #   it "checks if there is a piece in that spot and it is not yours" do
+  #     white_pawn = FactoryBot.create :sample_white_pawn,
+  #                  x_position: 3, y_position: 3
+  #     black_pawn = FactoryBot.create :sample_black_pawn,
+  #                  x_position: 4, y_position: 4
+
+  #     expect(white_pawn.can_capture?(black_pawn.x_position, black_pawn.y_position, black_pawn.color)).to be true
+  #   end
+  # end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -184,9 +184,26 @@ RSpec.describe Pawn, type: :model do
         game = FactoryBot.create(:sample_game)
         white_pawn = FactoryBot.create :sample_white_pawn,
                        x_position: 2, y_position: 2, game_id: game.id
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                       x_position: 4, y_position: 2, game_id: game.id
         black_pawn = FactoryBot.create :sample_black_pawn,
                        x_position: 3, y_position: 3, game_id: game.id        
         expect(black_pawn.valid_moves).to include({ x: 2, y: 2 })
+        expect(black_pawn.valid_moves).to include({ x: 4, y: 2 })
+      end
+      fit "should not update valid_moves with a diagonal square occupied by a black pawn" do
+        game = FactoryBot.create(:sample_game)
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                       x_position: 3, y_position: 3, game_id: game.id
+        black_pawn2 = FactoryBot.create :sample_black_pawn,
+                       x_position: 2, y_position: 2, game_id: game.id        
+        expect(black_pawn.valid_moves).not_to include({ x: 2, y: 2 })
+      end      
+      fit "should not update valid_moves with an unoccupied diagonal square" do
+        game = FactoryBot.create(:sample_game)
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                       x_position: 3, y_position: 3, game_id: game.id        
+        expect(black_pawn.valid_moves).not_to include({ x: 2, y: 2 })
       end
     end
   end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Pawn, type: :model do
 
   describe "#has_enemy_diagonal" do
     context "white piece" do
-      fit "says whether a white piece has an enemy black pawn in a diagonal square" do
+      it "says whether a white piece has an enemy black pawn in a diagonal square" do
         game = FactoryBot.create(:sample_game)
         white_pawn = FactoryBot.create :sample_white_pawn,
                        x_position: 3, y_position: 3, game_id: game.id
@@ -109,7 +109,7 @@ RSpec.describe Pawn, type: :model do
         expect(white_pawn.has_enemy_diagonal).to be true
       end
 
-      fit "returns false if it is the player's own piece in the specified square" do
+      it "returns false if it is the player's own piece in the specified square" do
         game = FactoryBot.create(:sample_game)
         white_pawn = FactoryBot.create :sample_white_pawn,
                         x_position: 3, y_position: 3, game_id: game.id
@@ -119,7 +119,7 @@ RSpec.describe Pawn, type: :model do
         expect(white_pawn.has_enemy_diagonal).to be false
       end
 
-      fit "returns false if there is no piece in the specified square" do
+      it "returns false if there is no piece in the specified square" do
         game = FactoryBot.create(:sample_game)
         white_pawn = FactoryBot.create :sample_white_pawn,
                         x_position: 3, y_position: 3, game_id: game.id
@@ -147,6 +147,18 @@ RSpec.describe Pawn, type: :model do
         
         expect(black_pawn.has_enemy_diagonal).to be false
       end
+    end
+  end
+
+
+  describe "#add_enemy_diagonal" do
+    fit "should update valid_moves with a diagonal square occupied by an enemy" do
+      game = FactoryBot.create(:sample_game)
+      white_pawn = FactoryBot.create :sample_white_pawn,
+                  x_position: 3, y_position: 3, game_id: game.id
+      black_pawn = FactoryBot.create :sample_black_pawn,
+                  x_position: 4, y_position: 4, game_id: game.id 
+      expect(white_pawn.valid_moves).to include({ x: 4, y: 4 })
     end
   end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Pawn, type: :model do
         white_pawn = FactoryBot.create :sample_white_pawn,
                      x_position: 3, y_position: 3
         
-        expect(white_pawn.valid_move?(4,4)).to be false
+        expect(white_pawn.valid_move?(2,4)).to be false
       end
     end
     context "black piece" do
@@ -91,7 +91,7 @@ RSpec.describe Pawn, type: :model do
         black_pawn = FactoryBot.create :sample_black_pawn,
                      x_position: 3, y_position: 3
 
-        expect(black_pawn.valid_move?(2,2)).to be false
+        expect(black_pawn.valid_move?(4,2)).to be false
       end
     end
   end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -160,5 +160,19 @@ RSpec.describe Pawn, type: :model do
                   x_position: 4, y_position: 4, game_id: game.id 
       expect(white_pawn.valid_moves).to include({ x: 4, y: 4 })
     end
+    fit "should not update valid_moves with a diagonal square occupied by yourself" do
+      game = FactoryBot.create(:sample_game)
+      white_pawn = FactoryBot.create :sample_white_pawn,
+                  x_position: 3, y_position: 3, game_id: game.id
+      white_pawn2 = FactoryBot.create :sample_white_pawn,
+                  x_position: 4, y_position: 4, game_id: game.id        
+      expect(white_pawn.valid_moves).not_to include({ x: 4, y: 4 })
+    end
+    fit "should not update valid_moves with an unoccupied diagonal square" do
+      game = FactoryBot.create(:sample_game)
+      white_pawn = FactoryBot.create :sample_white_pawn,
+                  x_position: 3, y_position: 3, game_id: game.id        
+      expect(white_pawn.valid_moves).not_to include({ x: 4, y: 4 })
+    end
   end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe Pawn, type: :model do
                      x_position: 3, y_position: 3
         expect(white_pawn.valid_move?(3,2)).to be false
       end
+
+      it "can move forward two spaces the first time it is moved" do
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                     x_position: 3, y_position: 3
+        expect(white_pawn.valid_move?(3,5)).to be true
+      end
+
+      it "cannot move forward two spaces after it has been moved" do
+        white_pawn = FactoryBot.create :sample_white_pawn,
+                     x_position: 3, y_position: 3
+        white_pawn.update_attributes({ x_position: 3, y_position: 4})
+
+        expect(white_pawn.valid_move?(3,6)).to be false
+      end
     end
     context "black piece" do
       it "can move forward" do
@@ -32,6 +46,20 @@ RSpec.describe Pawn, type: :model do
         black_pawn = FactoryBot.create :sample_black_pawn,
                      x_position: 3, y_position: 3
         expect(black_pawn.valid_move?(3,4)).to be false
+      end
+
+      it "can move forward two spaces the first time it is moved" do
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                     x_position: 3, y_position: 4
+        expect(black_pawn.valid_move?(3,2)).to be true
+      end
+
+      it "cannot move forward two spaces after it has been moved" do
+        black_pawn = FactoryBot.create :sample_black_pawn,
+                     x_position: 3, y_position: 4
+        black_pawn.update_attributes({ x_position: 3, y_position: 3})
+
+        expect(black_pawn.valid_move?(3,1)).to be false
       end
     end
   end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -158,8 +158,11 @@ RSpec.describe Pawn, type: :model do
         white_pawn = FactoryBot.create :sample_white_pawn,
                     x_position: 3, y_position: 3, game_id: game.id
         black_pawn = FactoryBot.create :sample_black_pawn,
-                    x_position: 4, y_position: 4, game_id: game.id 
+                    x_position: 4, y_position: 4, game_id: game.id
+        black_pawn2 = FactoryBot.create :sample_black_pawn,
+                    x_position: 2, y_position: 4, game_id: game.id        
         expect(white_pawn.valid_moves).to include({ x: 4, y: 4 })
+        expect(white_pawn.valid_moves).to include({ x: 2, y: 4 }) 
       end
       fit "should not update valid_moves with a diagonal square occupied by yourself" do
         game = FactoryBot.create(:sample_game)

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -9,4 +9,14 @@ RSpec.describe Piece, type: :model do
       expect(black_piece.is_white_piece?).to be false
     end
   end
+
+  describe "#has_been_moved?" do
+    it "checks if the piece has been moved" do
+      piece = FactoryBot.create :sample_black_pawn
+      expect(piece.has_been_moved?).to be false
+
+      piece.update_attributes(x_position: 2)
+      expect(piece.has_been_moved?).to be true
+    end
+  end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Piece, type: :model do
     end
   end
 
-  describe "#has_been_moved?" do
+  describe "#first_move?" do
     it "checks if the piece has been moved" do
       piece = FactoryBot.create :sample_black_pawn
       expect(piece.first_move?).to be true

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe Piece, type: :model do
   describe "#has_been_moved?" do
     it "checks if the piece has been moved" do
       piece = FactoryBot.create :sample_black_pawn
-      expect(piece.has_been_moved?).to be false
+      expect(piece.first_move?).to be true
 
       piece.update_attributes(x_position: 2)
-      expect(piece.has_been_moved?).to be true
+      expect(piece.first_move?).to be false
     end
   end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -2,10 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Piece, type: :model do
   describe "#is_white_piece?" do
-    it "tells a piece its color based on its player_id" do
-      game = Game.create(white_player_id: 1, black_player_id: 2)
-      white_piece = game.pieces.create(player_id: 1)
-      black_piece = game.pieces.create(player_id: 2)
+    it "checks if the piece is white" do
+      white_piece = FactoryBot.create :sample_white_pawn
+      black_piece = FactoryBot.create :sample_black_pawn
       expect(white_piece.is_white_piece?).to be true
       expect(black_piece.is_white_piece?).to be false
     end


### PR DESCRIPTION
This request includes:

- Tracking if it is the first turn for a pawn
- Allows the pawn to move two spaces on its first turn
- Allows for pawns to move only one direction by color
- Updated factories for white pawns, black pawns, and sample games
- Allows pawns to move diagonally when capturing an opposite color piece
- Updated piece Update test